### PR TITLE
Fix example syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ preloader.preloadImages returns a promise, so you could also handle the promise 
 	},
 	function() {
 	    // Loading failed on at least one image.
-	}
+	});
 
 #### That's it!
 


### PR DESCRIPTION
I fixed the promise syntax in the documentation, as it was incorrect and the error function never executed. `.then` accepts two parameters: the first one being a success function and the second one being an error function.
